### PR TITLE
PostgreSQL downgrade encryption from SCRAM to md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Available authorization method are `trust`, `password` and `md5`.
 Due to code size limit, `md5` method may be disabled in compilation time,
 decreasing code size for Arduino by some kilobytes.
 
+If `md5` is specified as a method in `pg_hba.conf` but the user's password on the PostgreSQL server is encrypted for SCRAM, then SCRAM-based authentication will automatically be chosen instead. Consider downgrading password encryption in PostgreSQL from SCRAM to md5 in `postgres.conf`. Then renew user passwords if allready created.
+
 All methods are asynchronous, but sometimes may block for a while in case of poor network connection.
 
 As column names and notifications are rarely needed in microcontrollers applications, may be disabled.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Available authorization method are `trust`, `password` and `md5`.
 Due to code size limit, `md5` method may be disabled in compilation time,
 decreasing code size for Arduino by some kilobytes.
 
-If `md5` is specified as a method in `pg_hba.conf` but the user's password on the PostgreSQL server is encrypted for SCRAM, then SCRAM-based authentication will automatically be chosen instead. Consider downgrading password encryption in PostgreSQL from SCRAM to md5 in `postgres.conf`. Then renew user passwords if allready created.
+If `md5` is specified as a method in `pg_hba.conf` but the user's password on the PostgreSQL server is encrypted for SCRAM, 
+then SCRAM-based authentication will automatically be chosen instead. 
+As a workaround, consider downgrading password encryption in PostgreSQL from SCRAM to md5 in `postgres.conf`. 
+Then renew user passwords on PostgreSQL server if already created.
 
 All methods are asynchronous, but sometimes may block for a while in case of poor network connection.
 


### PR DESCRIPTION
If `md5` is specified as a method in `pg_hba.conf` but the user's password on the PostgreSQL server is encrypted for SCRAM, then SCRAM-based authentication will automatically be chosen instead. As a workaround, consider downgrading password encryption in PostgreSQL from SCRAM to md5 in `postgres.conf`. Then renew user passwords if already created.